### PR TITLE
Bump DNSControl to 4.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ LABEL "com.github.actions.description"="Deploy your DNS configuration to multipl
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="yellow"
 
-ENV DNSCONTROL_VERSION="4.22.0"
-ENV DNSCONTROL_CHECKSUM="027e8bb41b3ac84bb17e406a4d6c769eac54fe3b0a22823550860cc8a835f803"
+ENV DNSCONTROL_VERSION="4.24.0"
+ENV DNSCONTROL_CHECKSUM="c9afc8155e38cd8a6b1c7a7966bf98fb5f4d6415d28c342b2742300d3f3e2df4"
 ENV USER=dnscontrol-user
 
 RUN apk -U --no-cache upgrade && \


### PR DESCRIPTION
Full details of this release can be found here: https://github.com/StackExchange/dnscontrol/releases/tag/v4.24.0